### PR TITLE
chore: docker-compose에 health check 구문 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,9 @@ services:
     env_file:
       - deploy.env
     depends_on:
-      - database
+      database:
+        # database가 확실히 실행되었을 때 spring app을 실행
+        condition: service_healthy
     ports:
       - ${SPRING_PORT}:${SPRING_PORT}
     restart: "no"
@@ -29,6 +31,10 @@ services:
     restart: "no"
     volumes:
       - aiary-database:/var/lib/mysql
+    # database가 확실히 실행되었을 때 spring app을 실행
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-P",
+              "${DB_PORT}", "-u", "${DB_USERNAME}", "-p${DB_PW}" ]
 
 volumes:
   aiary-database:


### PR DESCRIPTION
### ✔ 작업 내용

---

- docker-compose 파일에 원활한 빌드를 위한 구문을 몇 개 추가했습니다.
- database service의 실행이 보장된 상태에서 spring app이 실행될 수 있도록 조건문을 추가했습니다.
  - `condition: service_healthy`
- database service의 health check를 위한 test 구문을 추가했습니다.
  - `healthcheck:  test [ ... ]`

### ✔ 참고 사항

---

- health check 구문 없이 실행하니, communication link failure 로그가 뜨는데 database service 실행이 보장되지 않은 상태에서 spring app이 실행되어서 발생한 오류라고 판단했습니다.
- 여기저기 알아보며 '그냥 이렇게 하니 되네' 하고 추가한 구문이라서 근본적인 해결책은 아닐 수 있습니다. 피드백 자유롭게 해 주세요.

### ✔ 버그 리포트

---

-
-
-

### ✔ 기타 (레퍼런스, 여담)

---

- 로그인도 금방 개발할게요