### PR TITLE
feat: 회원가입 기능 구현

### DIFF
--- a/src/main/java/com/aiary/be/auth/application/AuthService.java
+++ b/src/main/java/com/aiary/be/auth/application/AuthService.java
@@ -1,12 +1,31 @@
 package com.aiary.be.auth.application;
 
 
+import com.aiary.be.auth.presentation.dto.LoginRequest;
+import com.aiary.be.user.domain.User;
 import com.aiary.be.user.persistent.UserRepository;
+import com.aiary.be.auth.presentation.dto.SignupRequest;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
+
     private final UserRepository userRepository;
+    // 회원가입: 신규 유저 등록
+    public void save(SignupRequest request) {
+        User newUser = User.builder()
+            .email(request.email())
+            .password(request.password())
+            .userName(request.userName())
+            .age(request.age())
+            .role(request.role())
+            .gender(request.gender())
+            .phoneNumber(request.phoneNumber())
+            .build();
+
+        userRepository.save(newUser);
+    }
 }

--- a/src/main/java/com/aiary/be/auth/presentation/AuthController.java
+++ b/src/main/java/com/aiary/be/auth/presentation/AuthController.java
@@ -19,9 +19,15 @@ public class AuthController {
     // Todo 회원 가입 기능
     @PostMapping("/register")
     public ResponseEntity<?> register(
+        @RequestBody SignupRequest signupRequest,
         HttpServletResponse httpServletResponse // 쿠키 전달용
     ) {
-        return new ResponseEntity<>(HttpStatus.CREATED);
+        authService.save(signupRequest);
+
+        // 회원가입 시에도 client에게 줘야 하는 쿠키가 있나요?
+        // 없으면 httpServletResponse는 이 메서드에서 사용 안 하는 걸로..
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
     
     // Todo 로그인 기능

--- a/src/main/java/com/aiary/be/auth/presentation/dto/SignupRequest.java
+++ b/src/main/java/com/aiary/be/auth/presentation/dto/SignupRequest.java
@@ -1,0 +1,14 @@
+package com.aiary.be.auth.presentation.dto;
+
+import com.aiary.be.user.domain.Gender;
+import com.aiary.be.user.domain.Role;
+
+public record SignupRequest(
+    String email,
+    String password,
+    String userName,
+    int age,
+    Gender gender,
+    Role role,
+    String phoneNumber
+) {}

--- a/src/main/java/com/aiary/be/user/domain/User.java
+++ b/src/main/java/com/aiary/be/user/domain/User.java
@@ -2,12 +2,16 @@ package com.aiary.be.user.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
### ✔ 작업 내용

---

- User entity를 참고해서 회원가입 기능을 구현했어요.
- 회원가입을 위한 요청 dto와 service 계층의 login 메서드를 추가했어요.

### ✔ 참고 사항

---

- 아직 비밀번호를 해싱해서 저장하지는 않아요. raw password를 그대로 저장합니다. 이후에 추가할게요.
- service 메서드에서 user 객체를 생성할 때 builder 패턴을 사용하도록 했어요.
  - 혹시 User.builder() 패턴이 아니라 User 객체 생성 static 메서드를 사용하는 게 나은 것 같으면 알려주세요. builder 패턴이 편해서 전 이거 사용하긴 했어요.

### ✔ 버그 리포트

---


### ✔ 기타 (레퍼런스, 여담)

---

- 쿠키와 세션도 빠르게 공부 중입니다;; 금방 구현해 놓을게요
- 쿠키/세션 작업 내용이랑 한 번에 묶어서 PR 보내려고 했는데, 혹시 작업마다 피드백할 게 많을 수도 있으니까 작업 내용은 최대한 잘게 쪼개서 PR 보내도록 해 봄..