### PR TITLE
Feat/#5 implement login

### DIFF
--- a/src/main/java/com/aiary/be/auth/application/AuthService.java
+++ b/src/main/java/com/aiary/be/auth/application/AuthService.java
@@ -1,6 +1,8 @@
 package com.aiary.be.auth.application;
 
 
+import com.aiary.be.global.exception.CustomException;
+import com.aiary.be.global.exception.errorCode.UserErrorCode;
 import com.aiary.be.user.domain.User;
 import com.aiary.be.user.persistent.UserRepository;
 import com.aiary.be.auth.presentation.dto.SignupRequest;
@@ -33,10 +35,11 @@ public class AuthService {
 
     public User login(String email, String password){
         User user = userRepository.findUserByEmail(email)
-            .orElse(null);
+            .orElseThrow(()-> CustomException.from(UserErrorCode.INVALID_EMAIL_PASSWORD));
 
-        if(user==null || !user.passwordMatches(password, passwordEncoder))
-            return null;
+        if(!user.passwordMatches(password, passwordEncoder)){
+            throw CustomException.from(UserErrorCode.INVALID_EMAIL_PASSWORD);
+        }
 
         return user;
     }

--- a/src/main/java/com/aiary/be/auth/application/AuthService.java
+++ b/src/main/java/com/aiary/be/auth/application/AuthService.java
@@ -1,11 +1,9 @@
 package com.aiary.be.auth.application;
 
 
-import com.aiary.be.auth.presentation.dto.LoginRequest;
 import com.aiary.be.user.domain.User;
 import com.aiary.be.user.persistent.UserRepository;
 import com.aiary.be.auth.presentation.dto.SignupRequest;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/aiary/be/auth/application/AuthService.java
+++ b/src/main/java/com/aiary/be/auth/application/AuthService.java
@@ -28,4 +28,14 @@ public class AuthService {
 
         userRepository.save(newUser);
     }
+
+    public User login(String email, String password){
+        User user = userRepository.findUserByEmail(email)
+            .orElse(null);
+
+        if(user==null || !user.getPassword().equals(password))
+            return null;
+
+        return user;
+    }
 }

--- a/src/main/java/com/aiary/be/auth/application/AuthService.java
+++ b/src/main/java/com/aiary/be/auth/application/AuthService.java
@@ -17,15 +17,16 @@ public class AuthService {
 
     // 회원가입: 신규 유저 등록
     public void save(SignupRequest request) {
-        User newUser = User.builder()
-            .email(request.email())
-            .password(passwordEncoder.encode(request.password()))
-            .userName(request.userName())
-            .age(request.age())
-            .role(request.role())
-            .gender(request.gender())
-            .phoneNumber(request.phoneNumber())
-            .build();
+        User newUser = new User(
+            request.email(),
+            request.password(),
+            request.userName(),
+            request.age(),
+            request.role(),
+            request.gender(),
+            request.phoneNumber(),
+            passwordEncoder
+        );
 
         userRepository.save(newUser);
     }
@@ -34,7 +35,7 @@ public class AuthService {
         User user = userRepository.findUserByEmail(email)
             .orElse(null);
 
-        if(user==null || !passwordEncoder.matches(password, user.getPassword()))
+        if(user==null || !user.passwordMatches(password, passwordEncoder))
             return null;
 
         return user;

--- a/src/main/java/com/aiary/be/auth/application/AuthService.java
+++ b/src/main/java/com/aiary/be/auth/application/AuthService.java
@@ -7,6 +7,7 @@ import com.aiary.be.user.persistent.UserRepository;
 import com.aiary.be.auth.presentation.dto.SignupRequest;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,11 +15,13 @@ import org.springframework.stereotype.Service;
 public class AuthService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
     // 회원가입: 신규 유저 등록
     public void save(SignupRequest request) {
         User newUser = User.builder()
             .email(request.email())
-            .password(request.password())
+            .password(passwordEncoder.encode(request.password()))
             .userName(request.userName())
             .age(request.age())
             .role(request.role())
@@ -33,7 +36,7 @@ public class AuthService {
         User user = userRepository.findUserByEmail(email)
             .orElse(null);
 
-        if(user==null || !user.getPassword().equals(password))
+        if(user==null || !passwordEncoder.matches(password, user.getPassword()))
             return null;
 
         return user;

--- a/src/main/java/com/aiary/be/auth/application/AuthService.java
+++ b/src/main/java/com/aiary/be/auth/application/AuthService.java
@@ -1,6 +1,7 @@
 package com.aiary.be.auth.application;
 
 
+import com.aiary.be.auth.presentation.dto.UserResponse;
 import com.aiary.be.global.exception.CustomException;
 import com.aiary.be.global.exception.errorCode.UserErrorCode;
 import com.aiary.be.user.domain.User;
@@ -33,7 +34,7 @@ public class AuthService {
         userRepository.save(newUser);
     }
 
-    public User login(String email, String password){
+    public UserResponse login(String email, String password){
         User user = userRepository.findUserByEmail(email)
             .orElseThrow(()-> CustomException.from(UserErrorCode.INVALID_EMAIL_PASSWORD));
 
@@ -41,6 +42,6 @@ public class AuthService {
             throw CustomException.from(UserErrorCode.INVALID_EMAIL_PASSWORD);
         }
 
-        return user;
+        return UserResponse.from(user);
     }
 }

--- a/src/main/java/com/aiary/be/auth/presentation/AuthController.java
+++ b/src/main/java/com/aiary/be/auth/presentation/AuthController.java
@@ -5,7 +5,6 @@ import com.aiary.be.auth.presentation.dto.LoginRequest;
 import com.aiary.be.auth.presentation.dto.SignupRequest;
 import com.aiary.be.global.response.Message;
 import com.aiary.be.user.domain.User;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
@@ -14,7 +13,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,21 +24,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
     private final AuthService authService;
 
-    // Todo 회원 가입 기능
+    // 회원가입
     @PostMapping("/register")
     public ResponseEntity<?> register(
-        @RequestBody SignupRequest signupRequest,
-        HttpServletResponse httpServletResponse // 쿠키 전달용
+        @RequestBody SignupRequest signupRequest
     ) {
         authService.save(signupRequest);
-
-        // 회원가입 시에도 client에게 줘야 하는 쿠키가 있나요?
-        // 없으면 httpServletResponse는 이 메서드에서 사용 안 하는 걸로..
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    // Todo 로그인 기능
+    // 로그인
     @PostMapping("/login")
     public ResponseEntity<?> login(
         @RequestBody LoginRequest loginRequest,

--- a/src/main/java/com/aiary/be/auth/presentation/AuthController.java
+++ b/src/main/java/com/aiary/be/auth/presentation/AuthController.java
@@ -57,6 +57,7 @@ public class AuthController {
         }
 
         // WAS가 알아서 JSESSIONID 쿠키를 응답에 추가
+        // userId, userName 필드를 따로 주지 않고, User 객체를 그대로 넣어줘도 될 듯
         HttpSession session = httpServletRequest.getSession();
         session.setAttribute("userId", user.getId());
         session.setAttribute("userName", user.getUserName());

--- a/src/main/java/com/aiary/be/auth/presentation/AuthController.java
+++ b/src/main/java/com/aiary/be/auth/presentation/AuthController.java
@@ -1,12 +1,22 @@
 package com.aiary.be.auth.presentation;
 
 import com.aiary.be.auth.application.AuthService;
+import com.aiary.be.auth.presentation.dto.LoginRequest;
+import com.aiary.be.auth.presentation.dto.SignupRequest;
+import com.aiary.be.global.response.Message;
+import com.aiary.be.user.domain.User;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,7 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auth")
 public class AuthController {
     private final AuthService authService;
-    
+
     // Todo 회원 가입 기능
     @PostMapping("/register")
     public ResponseEntity<?> register(
@@ -29,15 +39,49 @@ public class AuthController {
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
-    
+
     // Todo 로그인 기능
     @PostMapping("/login")
     public ResponseEntity<?> login(
+        @RequestBody LoginRequest loginRequest,
+        BindingResult bindingResult,
+        HttpServletRequest httpServletRequest,
         HttpServletResponse httpServletResponse // 쿠키 전달용
     ) {
-        return new ResponseEntity<>(HttpStatus.CREATED);
+        // 이후 bindingResult는 RequestBody의 유효성 검증 로직에 사용
+
+        User user = authService.login(loginRequest.getEmail(), loginRequest.getPassword());
+        if(user==null){
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(Message.from("로그인 정보가 일치하지 않습니다."));
+        }
+
+        // WAS가 알아서 JSESSIONID 쿠키를 응답에 추가
+        HttpSession session = httpServletRequest.getSession();
+        session.setAttribute("userId", user.getId());
+        session.setAttribute("userName", user.getUserName());
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(Message.from("로그인에 성공하였습니다."));
     }
-    
+
+    // 로그아웃 기능
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(
+        HttpServletRequest httpServletRequest
+    ){
+        // 기존 session 가져오기(없으면 null을 받아옴)
+        HttpSession session = httpServletRequest.getSession(false);
+
+        if(session!=null){
+            // 기존 session 존재 -> 무효화 필요함
+            session.invalidate();
+        }
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(Message.from("로그아웃에 성공하였습니다."));
+    }
+
     // Todo 써드 파티 OAuth
     @GetMapping("/oauth")
     public ResponseEntity<?> oauth(

--- a/src/main/java/com/aiary/be/auth/presentation/AuthController.java
+++ b/src/main/java/com/aiary/be/auth/presentation/AuthController.java
@@ -44,7 +44,7 @@ public class AuthController {
     ) {
         // 이후 bindingResult는 RequestBody의 유효성 검증 로직에 사용
 
-        User user = authService.login(loginRequest.getEmail(), loginRequest.getPassword());
+        User user = authService.login(loginRequest.email(), loginRequest.password());
         if(user==null){
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(Message.from("로그인 정보가 일치하지 않습니다."));

--- a/src/main/java/com/aiary/be/auth/presentation/AuthController.java
+++ b/src/main/java/com/aiary/be/auth/presentation/AuthController.java
@@ -5,6 +5,7 @@ import com.aiary.be.auth.presentation.dto.LoginRequest;
 import com.aiary.be.auth.presentation.dto.SignupRequest;
 import com.aiary.be.auth.presentation.dto.UserResponse;
 import com.aiary.be.global.response.Message;
+import com.aiary.be.global.util.SessionUtil;
 import com.aiary.be.user.domain.User;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -47,11 +48,7 @@ public class AuthController {
 
         UserResponse user = authService.login(loginRequest.email(), loginRequest.password());
 
-        // WAS가 알아서 JSESSIONID 쿠키를 응답에 추가
-        // userId, userName 필드를 따로 주지 않고, User 객체를 그대로 넣어줘도 될 듯
-        HttpSession session = httpServletRequest.getSession();
-        session.setAttribute("userId", user.userId());
-        session.setAttribute("userName", user.userName());
+        SessionUtil.setUserSession(httpServletRequest, user);
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(Message.from("로그인에 성공하였습니다."));
@@ -62,13 +59,7 @@ public class AuthController {
     public ResponseEntity<?> logout(
         HttpServletRequest httpServletRequest
     ){
-        // 기존 session 가져오기(없으면 null을 받아옴)
-        HttpSession session = httpServletRequest.getSession(false);
-
-        if(session!=null){
-            // 기존 session 존재 -> 무효화 필요함
-            session.invalidate();
-        }
+        SessionUtil.invalidateSession(httpServletRequest);
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(Message.from("로그아웃에 성공하였습니다."));

--- a/src/main/java/com/aiary/be/auth/presentation/AuthController.java
+++ b/src/main/java/com/aiary/be/auth/presentation/AuthController.java
@@ -3,6 +3,7 @@ package com.aiary.be.auth.presentation;
 import com.aiary.be.auth.application.AuthService;
 import com.aiary.be.auth.presentation.dto.LoginRequest;
 import com.aiary.be.auth.presentation.dto.SignupRequest;
+import com.aiary.be.auth.presentation.dto.UserResponse;
 import com.aiary.be.global.response.Message;
 import com.aiary.be.user.domain.User;
 import jakarta.servlet.http.HttpServletRequest;
@@ -44,17 +45,13 @@ public class AuthController {
     ) {
         // 이후 bindingResult는 RequestBody의 유효성 검증 로직에 사용
 
-        User user = authService.login(loginRequest.email(), loginRequest.password());
-        if(user==null){
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(Message.from("로그인 정보가 일치하지 않습니다."));
-        }
+        UserResponse user = authService.login(loginRequest.email(), loginRequest.password());
 
         // WAS가 알아서 JSESSIONID 쿠키를 응답에 추가
         // userId, userName 필드를 따로 주지 않고, User 객체를 그대로 넣어줘도 될 듯
         HttpSession session = httpServletRequest.getSession();
-        session.setAttribute("userId", user.getId());
-        session.setAttribute("userName", user.getUserName());
+        session.setAttribute("userId", user.userId());
+        session.setAttribute("userName", user.userName());
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(Message.from("로그인에 성공하였습니다."));

--- a/src/main/java/com/aiary/be/auth/presentation/dto/LoginRequest.java
+++ b/src/main/java/com/aiary/be/auth/presentation/dto/LoginRequest.java
@@ -6,12 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Getter
-@Setter
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
-public class LoginRequest {
-    private String email;
-    private String password;
-}
+public record LoginRequest(
+    String email,
+    String password
+){};

--- a/src/main/java/com/aiary/be/auth/presentation/dto/LoginRequest.java
+++ b/src/main/java/com/aiary/be/auth/presentation/dto/LoginRequest.java
@@ -1,0 +1,17 @@
+package com.aiary.be.auth.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class LoginRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/aiary/be/auth/presentation/dto/LoginRequest.java
+++ b/src/main/java/com/aiary/be/auth/presentation/dto/LoginRequest.java
@@ -1,11 +1,5 @@
 package com.aiary.be.auth.presentation.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-
 public record LoginRequest(
     String email,
     String password

--- a/src/main/java/com/aiary/be/auth/presentation/dto/UserResponse.java
+++ b/src/main/java/com/aiary/be/auth/presentation/dto/UserResponse.java
@@ -1,0 +1,28 @@
+package com.aiary.be.auth.presentation.dto;
+
+import com.aiary.be.user.domain.Gender;
+import com.aiary.be.user.domain.Role;
+import com.aiary.be.user.domain.User;
+
+public record UserResponse(
+    Long userId,
+    String email,
+    String userName,
+    int age,
+    Gender gender,
+    Role role,
+    String phoneNumber
+) {
+    public static UserResponse from(User user){
+        return new UserResponse(
+            user.getId(),
+            user.getEmail(),
+            user.getUserName(),
+            user.getAge(),
+            user.getGender(),
+            user.getRole(),
+            user.getPhoneNumber()
+        );
+    }
+
+}

--- a/src/main/java/com/aiary/be/global/config/AppConfig.java
+++ b/src/main/java/com/aiary/be/global/config/AppConfig.java
@@ -1,0 +1,15 @@
+package com.aiary.be.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AppConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/aiary/be/global/config/WebConfig.java
+++ b/src/main/java/com/aiary/be/global/config/WebConfig.java
@@ -3,7 +3,10 @@ package com.aiary.be.global.config;
 import com.aiary.be.global.interceptor.LoginCheckInterceptor;
 import com.aiary.be.global.resolver.LoginUserArgumentResolver;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -21,6 +24,7 @@ public class WebConfig implements WebMvcConfigurer {
             .addPathPatterns("/api/**")
             .excludePathPatterns(
                 "/api/auth/signup",
+                "/api/auth/register",
                 "/api/auth/login",
                 "/api/auth/logout",
                 "/error",
@@ -31,5 +35,10 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginUserArgumentResolver);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/aiary/be/global/config/WebConfig.java
+++ b/src/main/java/com/aiary/be/global/config/WebConfig.java
@@ -3,10 +3,7 @@ package com.aiary.be.global.config;
 import com.aiary.be.global.interceptor.LoginCheckInterceptor;
 import com.aiary.be.global.resolver.LoginUserArgumentResolver;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -23,7 +20,6 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(new LoginCheckInterceptor())
             .addPathPatterns("/api/**")
             .excludePathPatterns(
-                "/api/auth/signup",
                 "/api/auth/register",
                 "/api/auth/login",
                 "/api/auth/logout",

--- a/src/main/java/com/aiary/be/global/config/WebConfig.java
+++ b/src/main/java/com/aiary/be/global/config/WebConfig.java
@@ -32,9 +32,4 @@ public class WebConfig implements WebMvcConfigurer {
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginUserArgumentResolver);
     }
-
-    @Bean
-    public PasswordEncoder passwordEncoder(){
-        return new BCryptPasswordEncoder();
-    }
 }

--- a/src/main/java/com/aiary/be/global/config/WebConfig.java
+++ b/src/main/java/com/aiary/be/global/config/WebConfig.java
@@ -1,9 +1,11 @@
 package com.aiary.be.global.config;
 
+import com.aiary.be.global.interceptor.LoginCheckInterceptor;
 import com.aiary.be.global.resolver.LoginUserArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -12,7 +14,20 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
     private final LoginUserArgumentResolver loginUserArgumentResolver;
-    
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new LoginCheckInterceptor())
+            .addPathPatterns("/api/**")
+            .excludePathPatterns(
+                "/api/auth/signup",
+                "/api/auth/login",
+                "/api/auth/logout",
+                "/error",
+                "/favicon.ico"
+            );
+    }
+
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginUserArgumentResolver);

--- a/src/main/java/com/aiary/be/global/exception/errorCode/UserErrorCode.java
+++ b/src/main/java/com/aiary/be/global/exception/errorCode/UserErrorCode.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
-    NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 유저 아이디입니다.");
+    NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 유저 아이디입니다."),
+    INVALID_EMAIL_PASSWORD(HttpStatus.UNAUTHORIZED, "U002", "잘못된 이메일, 비밀번호 조합입니다.");
     
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/aiary/be/global/interceptor/LoginCheckInterceptor.java
+++ b/src/main/java/com/aiary/be/global/interceptor/LoginCheckInterceptor.java
@@ -1,0 +1,69 @@
+package com.aiary.be.global.interceptor;
+
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+@Slf4j
+public class LoginCheckInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        Object handler) throws Exception {
+
+        log.info("interceptor preHandle request url: {}", request.getRequestURI());
+
+        HttpSession session = request.getSession();
+
+        if(session==null || session.getAttribute("userId")==null){
+            log.warn("인증되지 않은 사용자, url: {}", request.getRequestURI());
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json;charset=UTF-8");
+            response.getWriter().write("{\"message\": \"로그인이 필요합니다.\"}");
+
+            return false;
+        }
+
+        // 이후 다른 페이지 인가 구현 예정
+//        if(request.getRequestURI().startsWith("/api/admin") &&
+//        !session.getAttribute("userRole").equals("ADMIN")){
+//            log.warn("일반 사용자는 이용할 수 없습니다.");
+//            ...
+//        }
+
+        // controller에서 자주 사용할 만한 것들은 @RequestAttribute()로 받아서 사용할 수 있도록 전달할 수 있다.
+//        request.setAttribute("userId", session.getAttribute("userId"));
+//        request.setAttribute("userEmail", session.getAttribute("userEmail"));
+
+        return true;
+    }
+
+    @Override
+    public void postHandle(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        Object handler,
+        ModelAndView modelAndView) throws Exception {
+
+        log.info("interceptor postHandle request url: {}", request.getRequestURI());
+
+        HandlerInterceptor.super.postHandle(request, response, handler, modelAndView);
+    }
+
+    @Override
+    public void afterCompletion(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        Object handler, Exception ex) throws Exception {
+
+        log.info("interceptor afterCompletion request url: {}", request.getRequestURI());
+
+        HandlerInterceptor.super.afterCompletion(request, response, handler, ex);
+    }
+}

--- a/src/main/java/com/aiary/be/global/interceptor/LoginCheckInterceptor.java
+++ b/src/main/java/com/aiary/be/global/interceptor/LoginCheckInterceptor.java
@@ -21,7 +21,7 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
 
         HttpSession session = request.getSession();
 
-        if(session==null || session.getAttribute("userId")==null){
+        if(session==null || session.getAttribute("loggedInUser")==null){
             log.warn("인증되지 않은 사용자, url: {}", request.getRequestURI());
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             response.setContentType("application/json;charset=UTF-8");

--- a/src/main/java/com/aiary/be/global/util/SessionUtil.java
+++ b/src/main/java/com/aiary/be/global/util/SessionUtil.java
@@ -1,0 +1,24 @@
+package com.aiary.be.global.util;
+
+import com.aiary.be.auth.presentation.dto.UserResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+
+public class SessionUtil{
+
+    // 세션에 사용자 정보 저장
+    // UserResponse 객체 자체를 session에 저장
+    public static void setUserSession(HttpServletRequest request, UserResponse user) {
+        HttpSession session = request.getSession();
+        session.setAttribute("loggedInUser", user);
+    }
+
+    // 세션을 무효화(로그아웃)
+    public static void invalidateSession(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.invalidate(); // 세션 무효화
+        }
+    }
+
+}

--- a/src/main/java/com/aiary/be/user/domain/User.java
+++ b/src/main/java/com/aiary/be/user/domain/User.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Entity
 @Getter
@@ -39,4 +40,19 @@ public class User {
     
     @Column
     private String phoneNumber;
+
+    public User(String email, String password, String userName, int age, Role role, Gender gender,
+        String phoneNumber, PasswordEncoder passwordEncoder) {
+        this.email = email;
+        this.password = passwordEncoder.encode(password);
+        this.userName = userName;
+        this.age = age;
+        this.role = role;
+        this.gender = gender;
+        this.phoneNumber = phoneNumber;
+    }
+
+    public boolean passwordMatches(String rawPassword, PasswordEncoder passwordEncoder){
+        return passwordEncoder.matches(rawPassword, this.password);
+    }
 }

--- a/src/main/java/com/aiary/be/user/persistent/UserRepository.java
+++ b/src/main/java/com/aiary/be/user/persistent/UserRepository.java
@@ -1,7 +1,9 @@
 package com.aiary.be.user.persistent;
 
 import com.aiary.be.user.domain.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findUserByEmail(String email);
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,11 @@
 server:
   port: ${SPRING_PORT}
-
+  servlet:
+    session:
+      timeout: 1800 # 세션 만료 시간 (1800s, 30m)
+      cookie:
+        name: JSESSIONID # 세션 쿠키 이름 (기본값)
+        http-only: true # JavaScript에서 쿠키 접근 불가 (XSS 방어)
 spring:
   application:
     name: be


### PR DESCRIPTION
### ✔ 작업 내용

---

- 사용자 로그인 및 세션 기반 사용자 인증 및 인가를 구현했어요.

### ✔ 참고 사항

---

- /api/auth/register, login, logout API를 개발했어요.
- register, login, logout을 제외한 다른 경로들은 로그인이 필요해요. 경로 목록은 WebConfig에서 확인할 수 있어요.
- Session에 지금은 userId, userName만 넣어서 전달하지만, 다른 필드값을 더 넣거나 User 객체 자체를 넣어서 전달해도 돼요. 나중에 천천히 수정할게요.
- HttpSession을 이용하면 개발자가 직접 Cookie를 다룰 일이 없네요..

### ✔ 버그 리포트

---


### ✔ 기타 (레퍼런스, 여담)

---

- 내일은 관리자 계정 하나 만들어놓고 user CRUD 개발해 봄