### PR TITLE
Feat : #12 외부 api 호출 성능을 개선했어요

### DIFF
--- a/src/main/java/com/aiary/be/report/application/ReportFacade.java
+++ b/src/main/java/com/aiary/be/report/application/ReportFacade.java
@@ -46,13 +46,13 @@ public class ReportFacade {
         LocalDate start = searchRange[0].toLocalDate();
         LocalDate end = searchRange[1].toLocalDate().minusDays(1);
         
-        // 유저 - 주간 다이어리 쌍
+        // 유저-주간 다이어리 쌍
         Map<Long, List<DiaryInfo>> userIdDiary = users.stream()
                                                      .collect(Collectors.toMap(
                                                          User::getId,
                                                          user -> diaryService.readDiaryInfos(user.getId(), searchRange)
                                                      ));
-        // 유저 - 주간 감정 쌍
+        // 유저-주간 감정 쌍
         Map<Long, Emotion> userIdEmotion = userIdDiary.keySet().stream()
                                           .collect(Collectors.toMap(
                                               userId -> userId,
@@ -68,10 +68,10 @@ public class ReportFacade {
                                           ));
         
         
+        // 핵심 : 외부 api 호출을 non-blocking으로 하고, 이후에 응답을 모아서 한 번에 bulk로 저장
         Flux.fromIterable(userIdDiary.entrySet())
             .flatMap(entry -> reportClient.analyze(entry.getKey(), entry.getValue()))
             .collectList()
-            .publishOn(Schedulers.boundedElastic())
             .publishOn(Schedulers.boundedElastic())
             .flatMap((apiResponses) -> {
                 List<Report> reports = new ArrayList<>();

--- a/src/main/java/com/aiary/be/report/application/ReportFacade.java
+++ b/src/main/java/com/aiary/be/report/application/ReportFacade.java
@@ -4,16 +4,25 @@ import com.aiary.be.diary.application.DiaryService;
 import com.aiary.be.diary.application.dto.DiaryInfo;
 import com.aiary.be.global.annotation.Facade;
 import com.aiary.be.global.util.DateUtil;
+import com.aiary.be.report.application.dto.AiResponse;
+import com.aiary.be.report.domain.Emotion;
 import com.aiary.be.report.domain.Report;
 import com.aiary.be.report.domain.ReportType;
 import com.aiary.be.user.application.UserService;
 import com.aiary.be.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Facade
@@ -27,34 +36,60 @@ public class ReportFacade {
     public void createReport(ReportType reportType) {
         // 전체 유저 조회
         List<User> users = userService.getAllUser();
-        
-        // Todo 로직 최적화해보기
-        // 유저마다 리포트 작성 ( 매주 월요일 00:05 또는 매월 1일 00:05 실행 )
+        Map<Long, User> userIdMap = new HashMap<>();
         for (User user : users) {
-            LocalDateTime[] searchRange = DateUtil.searchRange(reportType);
-            List<DiaryInfo> diaryInfos = diaryService.readDiaryInfos(user.getId(), searchRange);
-            String content = reportClient.analyze(diaryInfos);
-            
-            LocalDate start = searchRange[0].toLocalDate();
-            LocalDate end = searchRange[1].toLocalDate().minusDays(1);
-            Report report = new Report(
-                user,
-                start + " ~ " + end,
-                content,
-                reportType,
-                start,
-                end
-            );
-            
-            List<Integer> depressions = diaryInfos.stream().map(DiaryInfo::depression).toList();
-            List<Integer> angers = diaryInfos.stream().map(DiaryInfo::anger).toList();
-            List<Integer> happies = diaryInfos.stream().map(DiaryInfo::happy).toList();
-            
-            report.calculateDepression(depressions);
-            report.calculateAnger(angers);
-            report.calculateHappy(happies);
-            
-            reportService.createReport(report);
+            userIdMap.put(user.getId(), user);
         }
+        
+        // 범위 산정
+        LocalDateTime[] searchRange = DateUtil.searchRange(reportType);
+        LocalDate start = searchRange[0].toLocalDate();
+        LocalDate end = searchRange[1].toLocalDate().minusDays(1);
+        
+        // 유저 - 주간 다이어리 쌍
+        Map<Long, List<DiaryInfo>> userIdDiary = users.stream()
+                                                     .collect(Collectors.toMap(
+                                                         User::getId,
+                                                         user -> diaryService.readDiaryInfos(user.getId(), searchRange)
+                                                     ));
+        // 유저 - 주간 감정 쌍
+        Map<Long, Emotion> userIdEmotion = userIdDiary.keySet().stream()
+                                          .collect(Collectors.toMap(
+                                              userId -> userId,
+                                              userId -> {
+                                                  List<DiaryInfo> diaryInfos = userIdDiary.get(userId);
+                                                  List<Integer> depressions = diaryInfos.stream().map(DiaryInfo::depression).toList();
+                                                  List<Integer> angers = diaryInfos.stream().map(DiaryInfo::anger).toList();
+                                                  List<Integer> happies = diaryInfos.stream().map(DiaryInfo::happy).toList();
+                                                  Emotion emotion = new Emotion();
+                                                  emotion.calculateEmotion(depressions, angers, happies);
+                                                  return emotion;
+                                              }
+                                          ));
+        
+        
+        Flux.fromIterable(userIdDiary.entrySet())
+            .flatMap(entry -> reportClient.analyze(entry.getKey(), entry.getValue()))
+            .collectList()
+            .publishOn(Schedulers.boundedElastic())
+            .publishOn(Schedulers.boundedElastic())
+            .flatMap((apiResponses) -> {
+                List<Report> reports = new ArrayList<>();
+                for (AiResponse apiResponse : apiResponses) {
+                    reports.add(new Report(
+                        userIdMap.get(apiResponse.userId()),
+                        start + " - " + end,
+                        apiResponse.content(),
+                        reportType,
+                        start,
+                        end,
+                        userIdEmotion.get(apiResponse.userId())
+                    ));
+                }
+                
+                reportService.saveReportBulk(reports);
+                return Mono.empty();
+            })
+            .subscribe();
     }
 }

--- a/src/main/java/com/aiary/be/report/application/ReportService.java
+++ b/src/main/java/com/aiary/be/report/application/ReportService.java
@@ -10,6 +10,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class ReportService {
@@ -24,7 +26,7 @@ public class ReportService {
     }
     
     @Transactional
-    public void createReport(Report report) {
-        reportRepository.save(report);
+    public void saveReportBulk(List<Report> reports) {
+        reportRepository.saveAll(reports);
     }
 }

--- a/src/main/java/com/aiary/be/report/application/dto/AiResponse.java
+++ b/src/main/java/com/aiary/be/report/application/dto/AiResponse.java
@@ -1,0 +1,7 @@
+package com.aiary.be.report.application.dto;
+
+public record AiResponse(
+    Long userId,
+    String content
+) {
+}

--- a/src/main/java/com/aiary/be/report/application/dto/ReportInfo.java
+++ b/src/main/java/com/aiary/be/report/application/dto/ReportInfo.java
@@ -20,7 +20,7 @@ public record ReportInfo(
             report.getReportType().name(),
             DateUtil.dateFormating(report.getStartDate()),
             DateUtil.dateFormating(report.getEndDate()),
-            report.getDepression(), report.getAnger(), report.getHappy(),
+            report.getEmotion().getDepression(), report.getEmotion().getAnger(), report.getEmotion().getHappy(),
             report.getRiskScore()
         );
     }

--- a/src/main/java/com/aiary/be/report/domain/Emotion.java
+++ b/src/main/java/com/aiary/be/report/domain/Emotion.java
@@ -1,0 +1,51 @@
+package com.aiary.be.report.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+public class Emotion {
+    private int depression;
+    private int anger;
+    private int happy;
+    
+    public void calculateEmotion(
+        List<Integer> depressions, List<Integer> angers, List<Integer> happies
+    ) {
+        calculateDepression(depressions);
+        calculateAnger(angers);
+        calculateHappy(happies);
+    }
+    
+    private void calculateDepression(List<Integer> depressions) {
+        double average = depressions.stream()
+                             .mapToInt(Integer::intValue)
+                             .average()
+                             .orElse(0.0);
+        
+        this.depression = (int) average;
+    }
+    
+    private void calculateAnger(List<Integer> angers) {
+        double average = angers.stream()
+                             .mapToInt(Integer::intValue)
+                             .average()
+                             .orElse(0.0);
+        
+        this.anger = (int) average;
+    }
+    
+    private void calculateHappy(List<Integer> happies) {
+        double average = happies.stream()
+                             .mapToInt(Integer::intValue)
+                             .average()
+                             .orElse(0.0);
+        
+        this.happy = (int) average;
+    }
+}

--- a/src/main/java/com/aiary/be/report/domain/Report.java
+++ b/src/main/java/com/aiary/be/report/domain/Report.java
@@ -38,52 +38,26 @@ public class Report {
     @Column
     private LocalDate endDate;
     
-    @Column
-    private int depression;
-    
-    @Column
-    private int anger;
-    
-    @Column
-    private int happy;
+    @Embedded
+    private Emotion emotion;
     
     @Column
     private int riskScore;
     
-    public Report(User user, String title, String content, ReportType reportType, LocalDate startDate, LocalDate endDate) {
+    public Report(
+        User user,
+        String title, String content,
+        ReportType reportType,
+        LocalDate startDate, LocalDate endDate,
+        Emotion emotion
+    ) {
         this.user = user;
         this.title = title;
         this.content = content;
         this.reportType = reportType;
         this.startDate = startDate;
         this.endDate = endDate;
-    }
-    
-    public void calculateDepression(List<Integer> depressions) {
-        double average = depressions.stream()
-                              .mapToInt(Integer::intValue)
-                              .average()
-                              .orElse(0.0);
-        
-        this.depression = (int) average;
-    }
-    
-    public void calculateAnger(List<Integer> angers) {
-        double average = angers.stream()
-                             .mapToInt(Integer::intValue)
-                             .average()
-                             .orElse(0.0);
-        
-        this.anger = (int) average;
-    }
-    
-    public void calculateHappy(List<Integer> happies) {
-        double average = happies.stream()
-                             .mapToInt(Integer::intValue)
-                             .average()
-                             .orElse(0.0);
-        
-        this.happy = (int) average;
+        this.emotion = emotion;
     }
     
     public void calculateRisk(int riskScore) {

--- a/src/main/java/com/aiary/be/user/domain/User.java
+++ b/src/main/java/com/aiary/be/user/domain/User.java
@@ -18,7 +18,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     
-    @Column
+    @Column(unique = true)
     private String email;
     
     @Column


### PR DESCRIPTION
### ✔ 작업 내용

---

- Report 필드에 depression, anger, happy 필드를 @Embedded를 이용해서 묶었습니다
- WebClient의 반환 값을 Mono<>로 하고, 메서드 체이닝 과정의 .block()을 삭제해서 non-blocking 방식으로 변경했습니다
- 기존에 blocking 방식으로 api 호출 -> 대기 -> api 값 받기 -> db 저장으로 진행되던 report 생성 로직을 api 호출 (대기 x, 유저의 개수만큼 호출) -> 모든 유저의 호출이 끝나면 한 번에 db에 bulk 저장하는 방식으로 변경했습니다.

### ✔ 참고 사항

---

- 비동기 api 호출로 인해서 유저 id 순서가 아닌, 랜덤으로 리포트가 작성됩니다
- 근데 어차피 조회할 때는 id 같은 필드를 기준으로 조회해서 상관없을듯 합니다
- 결과적으로 API로 리포트를 생성하는 과정에서 유저가 200을 받기까지의 시간은 약 40s -> 0.7s 정도로 줄었습니다.
  - 근데 이게 DB 입력 동작이 메인 이벤트 루프가 돌아가는 스레드가 아닌, 별개의 스레드에서 처리되다보니, 실제로 0.7초만에 저장되지는 않습니다
  - 체감상 딱 1번 (3~4초 정도) 호출 시간 걸리는 거 같은데, 추후에 시간되면 테스트 해보겠습니다.

### ✔ 버그 리포트

---

- x

### ✔ 기타 (레퍼런스, 여담)

---