### PR TITLE
fix: 유효성 검증 마무리 및 interceptor 예외 로직 추가

### DIFF
--- a/src/main/java/com/aiary/be/auth/application/AuthService.java
+++ b/src/main/java/com/aiary/be/auth/application/AuthService.java
@@ -21,6 +21,10 @@ public class AuthService {
 
     // 회원가입: 신규 유저 등록
     public void save(SignupRequest request) {
+        if(userRepository.findUserByEmail(request.email()).isPresent()){
+            throw CustomException.from(UserErrorCode.DUPLICATE_EMAIL);
+        }
+
         User newUser = new User(
             request.email(),
             request.password(),

--- a/src/main/java/com/aiary/be/global/exception/errorCode/UserErrorCode.java
+++ b/src/main/java/com/aiary/be/global/exception/errorCode/UserErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements ErrorCode {
     NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 유저 아이디입니다."),
     INVALID_EMAIL_PASSWORD(HttpStatus.UNAUTHORIZED, "U002", "잘못된 이메일, 비밀번호 조합입니다."),
-    REQUIRED_LOGIN(HttpStatus.UNAUTHORIZED, "U003", "로그인이 필요합니다.");
+    REQUIRED_LOGIN(HttpStatus.UNAUTHORIZED, "U003", "로그인이 필요합니다."),
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST,  "U004", "이미 존재하는 이메일입니다.");
     
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/aiary/be/global/exception/errorCode/UserErrorCode.java
+++ b/src/main/java/com/aiary/be/global/exception/errorCode/UserErrorCode.java
@@ -1,12 +1,14 @@
 package com.aiary.be.global.exception.errorCode;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.graphql.GraphQlProperties.Http;
 import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
     NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "존재하지 않는 유저 아이디입니다."),
-    INVALID_EMAIL_PASSWORD(HttpStatus.UNAUTHORIZED, "U002", "잘못된 이메일, 비밀번호 조합입니다.");
+    INVALID_EMAIL_PASSWORD(HttpStatus.UNAUTHORIZED, "U002", "잘못된 이메일, 비밀번호 조합입니다."),
+    REQUIRED_LOGIN(HttpStatus.UNAUTHORIZED, "U003", "로그인이 필요합니다.");
     
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/aiary/be/global/interceptor/LoginCheckInterceptor.java
+++ b/src/main/java/com/aiary/be/global/interceptor/LoginCheckInterceptor.java
@@ -1,6 +1,8 @@
 package com.aiary.be.global.interceptor;
 
 
+import com.aiary.be.global.exception.CustomException;
+import com.aiary.be.global.exception.errorCode.UserErrorCode;
 import com.aiary.be.user.presentation.dto.UserResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -24,22 +26,10 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
 
         if(session==null || session.getAttribute("loggedInUser")==null){
             log.warn("인증되지 않은 사용자, url: {}", request.getRequestURI());
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setContentType("application/json;charset=UTF-8");
-            response.getWriter().write("{\"message\": \"로그인이 필요합니다.\"}");
 
-            return false;
+            throw CustomException.from(UserErrorCode.REQUIRED_LOGIN);
+
         }
-
-        // 이후 다른 페이지 인가 구현 예정
-//        if(request.getRequestURI().startsWith("/api/admin") &&
-//        !session.getAttribute("userRole").equals("ADMIN")){
-//            log.warn("일반 사용자는 이용할 수 없습니다.");
-//            ...
-//        }
-
-        // controller에서 자주 사용할 만한 것들은 @RequestAttribute()로 받아서 사용할 수 있도록 전달할 수 있다.
-//        request.setAttribute("userEmail", session.getAttribute("userEmail"));
         UserResponse userResponse = (UserResponse) session.getAttribute("loggedInUser");
         request.setAttribute("userId", userResponse.userId());
         return true;

--- a/src/main/java/com/aiary/be/user/presentation/UserApiController.java
+++ b/src/main/java/com/aiary/be/user/presentation/UserApiController.java
@@ -4,6 +4,7 @@ import com.aiary.be.global.response.Message;
 import com.aiary.be.user.application.UserService;
 import com.aiary.be.user.presentation.dto.UserRequest;
 import com.aiary.be.user.presentation.dto.UserResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,7 +28,7 @@ public class UserApiController {
     @PatchMapping
     public ResponseEntity<?> updateMyProfile(
         @RequestAttribute("userId") Long userId,
-        @RequestBody UserRequest userRequest
+        @Valid @RequestBody UserRequest userRequest
     ) {
         userService.updateUser(userId, userRequest);
 

--- a/src/main/java/com/aiary/be/user/presentation/dto/UserRequest.java
+++ b/src/main/java/com/aiary/be/user/presentation/dto/UserRequest.java
@@ -1,11 +1,13 @@
 package com.aiary.be.user.presentation.dto;
 
 import com.aiary.be.user.domain.Gender;
+import jakarta.validation.constraints.Email;
 
 // user 정보 update에만 사용되는 dto
 // 나중에 login/signup request 등이랑 통합 예정
 // 얘는 전달하지 않는 필드는 update하지 않기 때문에 valid를 추가하지 않았음
 public record UserRequest(
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
     String email,
     String password,
     String userName,


### PR DESCRIPTION
### ✔ 작업 내용

---

- 프로필 수정 api에서 이메일 필드에 제약조건을 추가했습니다.
  - 이메일 형식을 지켜서 수정 요청을 해야 해요.
  - 여전히 다른 필드들은 수정 요청 시에 제약 조건이 없어요. null이 아닌 필드만 수정합니다.
- 로그인이 필요한 경우에도 ProblemDetail 스펙에 따라 에러 메세지를 반환하도록 수정했습니다.
  - 기존에는 interceptor에서 바로 HttpServletResponse 객체에 전달 메세지를 담아서 반환했었어요.
  - 이제는 interceptor에서 CustomException을 발생시켜 다른 예외상황들과 마찬가지로 ControllerAdvice에서 처리합니다.
- 추가: 이미 존재하는 이메일로 회원가입 요청시에 service 계층에서 중복여부를 검사하고, 예외를 발생시킵니다.

### ✔ 참고 사항

---

x

### ✔ 버그 리포트

---

-
-
-

### ✔ 기타 (레퍼런스, 여담)

---

- API 명세서도 다시 작성했습니다.