### PR TITLE
Feat : #15 미션 도메인 프로토?타입 개발

### DIFF
--- a/src/main/java/com/aiary/be/auth/application/AuthService.java
+++ b/src/main/java/com/aiary/be/auth/application/AuthService.java
@@ -11,6 +11,7 @@ import com.aiary.be.auth.presentation.dto.SignupRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,8 +21,9 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
 
     // 회원가입: 신규 유저 등록
+    @Transactional
     public void save(SignupRequest request) {
-        if(userRepository.findUserByEmail(request.email()).isPresent()){
+        if(userRepository.existsByEmail(request.email())){
             throw CustomException.from(UserErrorCode.DUPLICATE_EMAIL);
         }
 
@@ -38,7 +40,8 @@ public class AuthService {
 
         userRepository.save(newUser);
     }
-
+    
+    @Transactional
     public UserResponse login(String email, String password){
         User user = userRepository.findUserByEmail(email)
             .orElseThrow(()-> CustomException.from(UserErrorCode.INVALID_EMAIL_PASSWORD));

--- a/src/main/java/com/aiary/be/diary/application/DiaryFacade.java
+++ b/src/main/java/com/aiary/be/diary/application/DiaryFacade.java
@@ -6,9 +6,11 @@ import com.aiary.be.global.annotation.Facade;
 import com.aiary.be.global.exception.CustomException;
 import com.aiary.be.global.exception.errorCode.DiaryErrorCode;
 import com.aiary.be.global.util.DateUtil;
+import com.aiary.be.mission.event.MissionEvent;
 import com.aiary.be.user.application.UserService;
 import com.aiary.be.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
@@ -18,6 +20,7 @@ import java.util.List;
 @Facade
 @RequiredArgsConstructor
 public class DiaryFacade {
+    private final ApplicationEventPublisher eventPublisher;
     private final DiaryService diaryService;
     private final UserService userService;
     
@@ -47,6 +50,13 @@ public class DiaryFacade {
         User user = userService.getUserForDiary(userId);
         
         diaryService.createDiary(user, diaryRequest);
+        
+        List<Boolean> booleans = weeklyWriteDiary(userId);
+        long count = booleans.stream()
+                        .filter(Boolean::booleanValue)
+                        .count();
+        
+        eventPublisher.publishEvent(new MissionEvent(userId, count));
     }
     
     public void updateDiary(Long userId, Long diaryId, DiaryRequest diaryRequest) {

--- a/src/main/java/com/aiary/be/diary/persistent/DiaryRepository.java
+++ b/src/main/java/com/aiary/be/diary/persistent/DiaryRepository.java
@@ -27,5 +27,8 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
         @Param("endDate") LocalDateTime end
     );
     
-    Optional<Diary> findByUserIdOrderByIdDesc(Long userId);
+    @Query("SELECT e from Diary e WHERE e.id = :userId ORDER BY e.id LIMIT 1")
+    Optional<Diary> findByUserIdOrderByIdDesc(
+        @Param("userId") Long userId
+    );
 }

--- a/src/main/java/com/aiary/be/global/scheduler/MissionScheduler.java
+++ b/src/main/java/com/aiary/be/global/scheduler/MissionScheduler.java
@@ -1,0 +1,15 @@
+package com.aiary.be.global.scheduler;
+
+import com.aiary.be.global.annotation.Scheduler;
+import com.aiary.be.mission.application.MissionFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Scheduler
+@RequiredArgsConstructor
+public class MissionScheduler {
+    private final MissionFacade missionFacade;
+    
+    @Scheduled(cron = "0 1 0 ? * MON")
+    public void initMissions() {missionFacade.initMission();}
+}

--- a/src/main/java/com/aiary/be/mission/application/MissionEventListener.java
+++ b/src/main/java/com/aiary/be/mission/application/MissionEventListener.java
@@ -1,0 +1,32 @@
+package com.aiary.be.mission.application;
+
+import com.aiary.be.mission.event.MissionEvent;
+import com.aiary.be.user.application.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MissionEventListener {
+    private static final int ESSENTIAL_MISSION_ONE = 1;
+    private static final int ESSENTIAL_MISSION_TWO = 5;
+    private static final int ESSENTIAL_MISSION_THREE = 7;
+    
+    private final UserService userService;
+    
+    @EventListener
+    public void essentialMissionCheck(MissionEvent missionEvent) {
+        int count = missionEvent.count().intValue();
+        
+        switch(count) {
+            case ESSENTIAL_MISSION_ONE -> userService.missionClear(missionEvent.userId(), 1);
+            case ESSENTIAL_MISSION_TWO -> userService.missionClear(missionEvent.userId(), 2);
+            case ESSENTIAL_MISSION_THREE -> userService.missionClear(missionEvent.userId(), 3);
+        }
+        
+        log.info("유저 " + missionEvent.userId() + "번의 필수 미션 1개 수행 완료");
+    }
+}

--- a/src/main/java/com/aiary/be/mission/application/MissionFacade.java
+++ b/src/main/java/com/aiary/be/mission/application/MissionFacade.java
@@ -1,0 +1,30 @@
+package com.aiary.be.mission.application;
+
+import com.aiary.be.global.annotation.Facade;
+import com.aiary.be.user.application.UserService;
+import com.aiary.be.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Facade
+@RequiredArgsConstructor
+public class MissionFacade {
+    private final MissionService missionService;
+    private final UserService userService;
+    
+    public void clearMission(Long userId, int number) {
+        userService.missionClear(userId, number);
+    }
+    
+    @Transactional
+    public void initMission() {
+        List<User> users = userService.getAllUser();
+        for (User user : users) {
+            user.resetWeeklyMission();
+        }
+        
+        missionService.shuffleMission();
+    }
+}

--- a/src/main/java/com/aiary/be/mission/application/MissionService.java
+++ b/src/main/java/com/aiary/be/mission/application/MissionService.java
@@ -1,0 +1,51 @@
+package com.aiary.be.mission.application;
+
+import com.aiary.be.mission.application.dto.MissionInfo;
+import com.aiary.be.mission.domain.Mission;
+import com.aiary.be.mission.persistent.MissionRepository;
+import com.aiary.be.mission.presentation.dto.MissionRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MissionService {
+    private final static int NON_ESSENTIAL_MISSION_NUMBER = 3;
+    
+    private final MissionRepository missionRepository;
+    
+    @Transactional(readOnly = true)
+    public List<MissionInfo> getWeeklyMission() {
+        List<Mission> essentialMissions = missionRepository.findByEssentialIsTrue();
+        essentialMissions.addAll(missionRepository.findByEssentialIsFalseAndActivateIsTrue());
+        
+        return essentialMissions.stream()
+                   .map(MissionInfo::from).toList();
+    }
+    
+    @Transactional
+    public void makeMission(MissionRequest missionRequest) {
+        Mission mission = new Mission(missionRequest.content(), missionRequest.essential());
+        
+        missionRepository.save(mission);
+    }
+    
+    @Transactional
+    public void shuffleMission() {
+        List<Mission> missions = missionRepository.findByEssentialIsFalse();
+        for (Mission mission : missions) {
+            mission.deactivate();
+        }
+        
+        Collections.shuffle(missions);
+        List<Mission> targets = missions.subList(0, NON_ESSENTIAL_MISSION_NUMBER);
+        
+        for (Mission target : targets) {
+            target.activate();
+        }
+    }
+}

--- a/src/main/java/com/aiary/be/mission/application/dto/MissionInfo.java
+++ b/src/main/java/com/aiary/be/mission/application/dto/MissionInfo.java
@@ -1,0 +1,11 @@
+package com.aiary.be.mission.application.dto;
+
+import com.aiary.be.mission.domain.Mission;
+
+public record MissionInfo(
+    String content
+) {
+    public static MissionInfo from(Mission mission) {
+        return new MissionInfo(mission.getContent());
+    }
+}

--- a/src/main/java/com/aiary/be/mission/domain/Mission.java
+++ b/src/main/java/com/aiary/be/mission/domain/Mission.java
@@ -20,19 +20,19 @@ public class Mission {
     private boolean essential;
     
     @Column
-    private boolean activate;
+    private boolean activated;
     
     public Mission(String content, boolean essential) {
         this.content = content;
         this.essential = essential;
-        this.activate = false;
+        this.activated = false;
     }
     
     public void activate() {
-        this.activate = true;
+        this.activated = true;
     }
     
     public void deactivate() {
-        this.activate = false;
+        this.activated = false;
     }
 }

--- a/src/main/java/com/aiary/be/mission/domain/Mission.java
+++ b/src/main/java/com/aiary/be/mission/domain/Mission.java
@@ -1,0 +1,38 @@
+package com.aiary.be.mission.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Mission {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column
+    private String content;
+    
+    @Column
+    private boolean essential;
+    
+    @Column
+    private boolean activate;
+    
+    public Mission(String content, boolean essential) {
+        this.content = content;
+        this.essential = essential;
+        this.activate = false;
+    }
+    
+    public void activate() {
+        this.activate = true;
+    }
+    
+    public void deactivate() {
+        this.activate = false;
+    }
+}

--- a/src/main/java/com/aiary/be/mission/event/MissionEvent.java
+++ b/src/main/java/com/aiary/be/mission/event/MissionEvent.java
@@ -1,0 +1,6 @@
+package com.aiary.be.mission.event;
+
+public record MissionEvent(
+    Long userId, Long count
+) {
+}

--- a/src/main/java/com/aiary/be/mission/persistent/MissionRepository.java
+++ b/src/main/java/com/aiary/be/mission/persistent/MissionRepository.java
@@ -1,0 +1,14 @@
+package com.aiary.be.mission.persistent;
+
+import com.aiary.be.mission.domain.Mission;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MissionRepository extends JpaRepository<Mission, Long> {
+    List<Mission> findByEssentialIsTrue();
+    
+    List<Mission> findByEssentialIsFalse();
+    
+    List<Mission> findByEssentialIsFalseAndActivateIsTrue();
+}

--- a/src/main/java/com/aiary/be/mission/presentation/MissionController.java
+++ b/src/main/java/com/aiary/be/mission/presentation/MissionController.java
@@ -1,7 +1,9 @@
 package com.aiary.be.mission.presentation;
 
 import com.aiary.be.global.response.Message;
+import com.aiary.be.mission.application.MissionFacade;
 import com.aiary.be.mission.application.MissionService;
+import com.aiary.be.mission.presentation.dto.ClearNumber;
 import com.aiary.be.mission.presentation.dto.MissionRequest;
 import com.aiary.be.mission.presentation.dto.MissionResponse;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MissionController {
     private final MissionService missionService;
+    private final MissionFacade missionFacade;
     
     @GetMapping
     public ResponseEntity<?> getMissions() {
@@ -38,5 +41,22 @@ public class MissionController {
         missionService.shuffleMission();
         
         return new ResponseEntity<>(Message.from("미션이 변경되었습니다."), HttpStatus.OK);
+    }
+    
+    @PostMapping("/clear")
+    public ResponseEntity<?> clearMission(
+        @RequestBody ClearNumber clearNumber,
+        @RequestAttribute("userId") Long userId
+    ) {
+        missionFacade.clearMission(userId, clearNumber.number());
+        
+        return new ResponseEntity<>(Message.from("미션" + clearNumber.number() + "이 해결되었습니다"), HttpStatus.OK);
+    }
+    
+    @PostMapping("/init")
+    public ResponseEntity<?> forceInitMission() {
+        missionFacade.initMission();
+        
+        return new ResponseEntity<>(Message.from("미션이 초기화 되었습니다"), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/aiary/be/mission/presentation/MissionController.java
+++ b/src/main/java/com/aiary/be/mission/presentation/MissionController.java
@@ -1,0 +1,42 @@
+package com.aiary.be.mission.presentation;
+
+import com.aiary.be.global.response.Message;
+import com.aiary.be.mission.application.MissionService;
+import com.aiary.be.mission.presentation.dto.MissionRequest;
+import com.aiary.be.mission.presentation.dto.MissionResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/mission")
+@RequiredArgsConstructor
+public class MissionController {
+    private final MissionService missionService;
+    
+    @GetMapping
+    public ResponseEntity<?> getMissions() {
+        List<MissionResponse> response = missionService.getWeeklyMission().stream()
+                                             .map(MissionResponse::from).toList();
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+    
+    @PostMapping
+    public ResponseEntity<?> addMissions(
+        @RequestBody MissionRequest missionRequest
+    ) {
+        missionService.makeMission(missionRequest);
+        
+        return new ResponseEntity<>(Message.from("미션이 생성되었습니다."), HttpStatus.CREATED);
+    }
+    
+    @PostMapping("/shuffle")
+    public ResponseEntity<?> shuffleMissions() {
+        missionService.shuffleMission();
+        
+        return new ResponseEntity<>(Message.from("미션이 변경되었습니다."), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/aiary/be/mission/presentation/dto/ClearNumber.java
+++ b/src/main/java/com/aiary/be/mission/presentation/dto/ClearNumber.java
@@ -1,0 +1,6 @@
+package com.aiary.be.mission.presentation.dto;
+
+public record ClearNumber(
+    int number
+) {
+}

--- a/src/main/java/com/aiary/be/mission/presentation/dto/MissionRequest.java
+++ b/src/main/java/com/aiary/be/mission/presentation/dto/MissionRequest.java
@@ -1,0 +1,7 @@
+package com.aiary.be.mission.presentation.dto;
+
+public record MissionRequest(
+    String content,
+    boolean essential
+) {
+}

--- a/src/main/java/com/aiary/be/mission/presentation/dto/MissionResponse.java
+++ b/src/main/java/com/aiary/be/mission/presentation/dto/MissionResponse.java
@@ -1,0 +1,11 @@
+package com.aiary.be.mission.presentation.dto;
+
+import com.aiary.be.mission.application.dto.MissionInfo;
+
+public record MissionResponse(
+    String content
+) {
+    public static MissionResponse from(MissionInfo missionInfo) {
+        return new MissionResponse(missionInfo.content());
+    }
+}

--- a/src/main/java/com/aiary/be/user/application/UserService.java
+++ b/src/main/java/com/aiary/be/user/application/UserService.java
@@ -44,6 +44,13 @@ public class UserService {
 
         userRepository.deleteById(userId);
     }
+    
+    public List<Boolean> getBooleanWeeklyMission(Long userId) {
+        User user = userRepository.findById(userId)
+                        .orElseThrow(() -> CustomException.from(UserErrorCode.NOT_FOUND));
+        
+        return user.getWeeklyMissionBool();
+    }
 
     // for other domains
 

--- a/src/main/java/com/aiary/be/user/application/UserService.java
+++ b/src/main/java/com/aiary/be/user/application/UserService.java
@@ -35,13 +35,13 @@ public class UserService {
 
         user.update(request.email(), request.password(), request.userName(), request.age(),
             request.gender(), request.phoneNumber(), passwordEncoder);
-
     }
 
     public void deleteUser(Long userId){
-        userRepository.findById(userId)
-            .orElseThrow(() -> CustomException.from(UserErrorCode.NOT_FOUND));
-
+        if(!userRepository.existsById(userId)) {
+            throw CustomException.from(UserErrorCode.NOT_FOUND);
+        }
+        
         userRepository.deleteById(userId);
     }
     

--- a/src/main/java/com/aiary/be/user/application/UserService.java
+++ b/src/main/java/com/aiary/be/user/application/UserService.java
@@ -65,4 +65,13 @@ public class UserService {
     public List<User> getAllUser() {
         return userRepository.findAll();
     }
+    
+    @Transactional
+    public void missionClear(Long userId, int number) {
+        User user = userRepository.findById(userId).orElseThrow(
+            () -> CustomException.from(UserErrorCode.NOT_FOUND)
+        );
+        
+        user.missionClear(number);
+    }
 }

--- a/src/main/java/com/aiary/be/user/domain/User.java
+++ b/src/main/java/com/aiary/be/user/domain/User.java
@@ -85,7 +85,9 @@ public class User {
     }
     
     public void missionClear(int number) {
-        this.weeklyMission += (int) Math.pow(2, number - 1);
+        if ((weeklyMission & (1 << (number - 1))) == 0) {
+            weeklyMission |= (1 << (number - 1));
+        }
     }
     
     public List<Boolean> getWeeklyMissionBool() {

--- a/src/main/java/com/aiary/be/user/domain/User.java
+++ b/src/main/java/com/aiary/be/user/domain/User.java
@@ -84,6 +84,10 @@ public class User {
         this.weeklyMission = 0;
     }
     
+    public void missionClear(int number) {
+        this.weeklyMission += (int) Math.pow(2, number - 1);
+    }
+    
     public List<Boolean> getWeeklyMissionBool() {
         ArrayList<Boolean> response = new ArrayList<>();
         

--- a/src/main/java/com/aiary/be/user/domain/User.java
+++ b/src/main/java/com/aiary/be/user/domain/User.java
@@ -14,6 +14,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -47,6 +50,9 @@ public class User {
 
     @Column
     private String phoneNumber;
+    
+    @Column
+    private int weeklyMission;
 
     public User(String email, String password, String userName, int age, Role role, Gender gender,
         String phoneNumber, PasswordEncoder passwordEncoder) {
@@ -57,6 +63,7 @@ public class User {
         this.role = role;
         this.gender = gender;
         this.phoneNumber = phoneNumber;
+        this.weeklyMission = 0;
     }
 
     public boolean passwordMatches(String rawPassword, PasswordEncoder passwordEncoder) {
@@ -71,5 +78,20 @@ public class User {
         this.age = age!=0?age:this.age;
         this.gender = gender!=null?gender:this.gender;
         this.phoneNumber = phoneNumber!=null?phoneNumber:this.phoneNumber;
+    }
+    
+    public void resetWeeklyMission() {
+        this.weeklyMission = 0;
+    }
+    
+    public List<Boolean> getWeeklyMissionBool() {
+        ArrayList<Boolean> response = new ArrayList<>();
+        
+        for (int i = 0; i < 6; i++) {
+            // (mask >> i) & 1이 1이면 true, 아니면 false
+            response.add(((weeklyMission >> i) & 1) == 1);
+        }
+        
+        return response;
     }
 }

--- a/src/main/java/com/aiary/be/user/persistent/UserRepository.java
+++ b/src/main/java/com/aiary/be/user/persistent/UserRepository.java
@@ -1,9 +1,12 @@
 package com.aiary.be.user.persistent;
 
 import com.aiary.be.user.domain.User;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
+    
     Optional<User> findUserByEmail(String email);
 }

--- a/src/main/java/com/aiary/be/user/presentation/UserApiController.java
+++ b/src/main/java/com/aiary/be/user/presentation/UserApiController.java
@@ -2,6 +2,7 @@ package com.aiary.be.user.presentation;
 
 import com.aiary.be.global.response.Message;
 import com.aiary.be.user.application.UserService;
+import com.aiary.be.user.presentation.dto.MissionProgressResponse;
 import com.aiary.be.user.presentation.dto.UserRequest;
 import com.aiary.be.user.presentation.dto.UserResponse;
 import lombok.RequiredArgsConstructor;
@@ -43,5 +44,16 @@ public class UserApiController {
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(Message.from("계정 삭제에 성공하였습니다."));
+    }
+    
+    @GetMapping("/mission")
+    public ResponseEntity<?> getWeeklyMissionProgress(
+        @RequestAttribute("userId") Long userId
+    ) {
+        MissionProgressResponse response = MissionProgressResponse.from(
+            userService.getBooleanWeeklyMission(userId)
+        );
+        
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/aiary/be/user/presentation/dto/MissionProgressResponse.java
+++ b/src/main/java/com/aiary/be/user/presentation/dto/MissionProgressResponse.java
@@ -1,0 +1,11 @@
+package com.aiary.be.user.presentation.dto;
+
+import java.util.List;
+
+public record MissionProgressResponse(
+    List<Boolean> progress
+) {
+    public static MissionProgressResponse from(List<Boolean> progress) {
+        return new MissionProgressResponse(progress);
+    }
+}


### PR DESCRIPTION
### ✔ 작업 내용

---

- findBy~로 엔티티를 가져와서 null 여부 검사하는 로직을 exist 메서드로 바꿨습니다
  - 이게 좀 더 직관적인 거 같아서 바꿔봤습니다, 다시 돌려놔도 됩니다
- 하루에 여러 개의 다이어리를 적지 못하게 하는 제약 조건에서 문제가 생겨서 JPQL로 재작성했습니다
- 미션 도메인을 구현했습니다
  - 미션 : 필수 미션 3개 + 그냥 미션 3개
  - 필수 미션 : 주에 다이어리 1개, 5개, 7개 적기
    - 필수 미션은 다이어리 작성시 자동으로 클리어 처리 됩니다
  - 그냥 미션 : 그 외 미션 테이블에서 랜덤으로 원소 선정하기
    - 그냥 미션은 직접 API 호출을 통해서 클리어해야 합니다
- 미션 초기화도 스케줄러로 등록 해놨습니다

### ✔ 참고 사항

---

- 변경 가능성이 많습니다

### ✔ 버그 리포트

---

- x

### ✔ 기타 (레퍼런스, 여담)

---

- 관리자 페이지를 만들면 어떨까합니다.
-
-