### PR TITLE
Feat/#16 상담소 조회 API 구현

### DIFF
--- a/src/main/java/com/aiary/be/counsel/application/CounselService.java
+++ b/src/main/java/com/aiary/be/counsel/application/CounselService.java
@@ -1,0 +1,39 @@
+package com.aiary.be.counsel.application;
+
+import com.aiary.be.counsel.application.dto.CounselData;
+import com.aiary.be.counsel.application.dto.RawResult;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class CounselService {
+
+    private final WebClient webClient;
+
+    @Value("${COUNSEL_API_KEY}")
+    private String serviceKey;
+
+    // 시(city), 구(district) 정보를 받아서 해당 지역의 정신재활센터 list를 보여주는 메서드
+    public Mono<List<CounselData>> getCounselListByCity(String city, String district){
+
+        return webClient.get()
+            .uri(uriBuilder ->uriBuilder
+                .path("/3049990/v1/uddi:14a6ea21-af95-4440-bb05-81698f7a1987")
+                .queryParam("serviceKey", serviceKey)
+                .queryParam("returnType", "JSON")
+                .queryParam("page", 1)
+                // 총 데이터셋이 2786행. 넉넉하게 3000개 한 번에 조회합니다.
+                .queryParam("perPage", 3000)
+                .build())
+            .retrieve()
+            .bodyToMono(RawResult.class)
+            .map(rawResult -> rawResult.data().stream()
+                    .filter(counselData -> counselData.adr()!=null && counselData.adr().contains(city))
+                    .toList());
+    }
+}

--- a/src/main/java/com/aiary/be/counsel/application/CounselService.java
+++ b/src/main/java/com/aiary/be/counsel/application/CounselService.java
@@ -3,25 +3,36 @@ package com.aiary.be.counsel.application;
 import com.aiary.be.counsel.application.dto.CounselData;
 import com.aiary.be.counsel.application.dto.RawResult;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 @Service
-@RequiredArgsConstructor
 public class CounselService {
 
-    private final WebClient webClient;
+    private final WebClient counselWebClient;
+    private final WebClient kakaoWebClient;
+    private final String serviceKey;
+    private final String kakaoServiceKey;
 
-    @Value("${COUNSEL_API_KEY}")
-    private String serviceKey;
+    public CounselService(
+        @Qualifier("counselWebClient") WebClient counselWebClient,
+        @Qualifier("kakaoWebClient") WebClient kakaoWebClient,
+        @Value("${COUNSEL_API_KEY}") String serviceKey,
+        @Value("${KAKAO_API_KEY}") String kakaoServiceKey) {
+        this.counselWebClient = counselWebClient;
+        this.kakaoWebClient = kakaoWebClient;
+        this.serviceKey = serviceKey;
+        this.kakaoServiceKey = kakaoServiceKey;
+    }
+
 
     // 시(city), 구(district) 정보를 받아서 해당 지역의 정신재활센터 list를 보여주는 메서드
     public Mono<List<CounselData>> getCounselListByCity(String city, String district){
 
-        return webClient.get()
+        return counselWebClient.get()
             .uri(uriBuilder ->uriBuilder
                 .path("/3049990/v1/uddi:14a6ea21-af95-4440-bb05-81698f7a1987")
                 .queryParam("serviceKey", serviceKey)
@@ -36,4 +47,12 @@ public class CounselService {
                     .filter(counselData -> counselData.adr()!=null && counselData.adr().contains(city))
                     .toList());
     }
+
+    // 도로명주소 -> 위도/경도 추출하는 메서드(kakao map API 이용)
+    public void getCounselGpsListByRoadname(List<CounselData> roadnames){
+
+        String sample = roadnames.get(0).adr();
+
+    }
+
 }

--- a/src/main/java/com/aiary/be/counsel/application/dto/CounselData.java
+++ b/src/main/java/com/aiary/be/counsel/application/dto/CounselData.java
@@ -1,0 +1,17 @@
+package com.aiary.be.counsel.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record CounselData(
+    @JsonProperty("기관명")
+    String name,
+
+//    @JsonProperty("기관구분")
+//    String category,
+
+    @JsonProperty("주소")
+    String adr
+
+//    @JsonProperty("홈페이지")
+//    String website
+){}

--- a/src/main/java/com/aiary/be/counsel/application/dto/RawResult.java
+++ b/src/main/java/com/aiary/be/counsel/application/dto/RawResult.java
@@ -1,0 +1,12 @@
+package com.aiary.be.counsel.application.dto;
+
+import java.util.List;
+
+public record RawResult(
+    int page,
+    int perPage,
+    int totalCount,
+    int currentCount,
+    int matchCount,
+    List<CounselData> data
+) {}

--- a/src/main/java/com/aiary/be/counsel/domain/Counsel.java
+++ b/src/main/java/com/aiary/be/counsel/domain/Counsel.java
@@ -1,0 +1,34 @@
+package com.aiary.be.counsel.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+// 사실 상담소 정보를 db에 저장은 따로 안 함. 사용하지 않는 entity인데 혹시 몰라서 일단 만들어놓기만 했어요.
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Counsel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private Double latitude;
+
+    @Column
+    private Double longitude;
+
+    @Column
+    private String name;
+
+    @Column
+    private String phoneNumber;
+}

--- a/src/main/java/com/aiary/be/counsel/presentation/CounselApiController.java
+++ b/src/main/java/com/aiary/be/counsel/presentation/CounselApiController.java
@@ -1,7 +1,9 @@
 package com.aiary.be.counsel.presentation;
 
 import com.aiary.be.counsel.application.CounselService;
+import com.aiary.be.counsel.application.dto.CounselData;
 import com.aiary.be.counsel.presentation.dto.CounselResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,14 +18,28 @@ public class CounselApiController {
 
     private final CounselService counselService;
 
-    @GetMapping
-    public Mono<?> getCounselListByCity(
+    // 시설의 도로명 주소 리스트를 반환
+    @GetMapping("/roadName")
+    public Mono<?> getCounselRoadNameListByCity(
         @RequestParam(name="city") String city,
         // 시/구까지 받고 있긴 한데, 시만 받아도 괜찮을 것 같긴 해요.
         @RequestParam(name="district") String district
     ){
         return counselService.getCounselListByCity(city, district)
             .map(CounselResponse::from);
+    }
+
+    // 시설의 위도/경도 리스트를 반환: 아직 구현 전
+    @GetMapping("/gps")
+    public Mono<?> getCounselGpsListByCity(
+        @RequestParam(name="city") String city,
+        @RequestParam(name="district") String district
+    ){
+        var roadnames = counselService.getCounselListByCity(city, district);
+
+        counselService.getCounselGpsListByRoadname((List<CounselData>) roadnames);
+
+        return null;
     }
 
 }

--- a/src/main/java/com/aiary/be/counsel/presentation/CounselApiController.java
+++ b/src/main/java/com/aiary/be/counsel/presentation/CounselApiController.java
@@ -1,0 +1,29 @@
+package com.aiary.be.counsel.presentation;
+
+import com.aiary.be.counsel.application.CounselService;
+import com.aiary.be.counsel.presentation.dto.CounselResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api/counsel")
+@RequiredArgsConstructor
+public class CounselApiController {
+
+    private final CounselService counselService;
+
+    @GetMapping
+    public Mono<?> getCounselListByCity(
+        @RequestParam(name="city") String city,
+        // 시/구까지 받고 있긴 한데, 시만 받아도 괜찮을 것 같긴 해요.
+        @RequestParam(name="district") String district
+    ){
+        return counselService.getCounselListByCity(city, district)
+            .map(CounselResponse::from);
+    }
+
+}

--- a/src/main/java/com/aiary/be/counsel/presentation/dto/CounselResponse.java
+++ b/src/main/java/com/aiary/be/counsel/presentation/dto/CounselResponse.java
@@ -1,0 +1,13 @@
+package com.aiary.be.counsel.presentation.dto;
+
+import com.aiary.be.counsel.application.dto.CounselData;
+import java.util.List;
+
+public record CounselResponse (
+    int totalCount,
+    List<CounselData> data
+){
+    public static CounselResponse from(List<CounselData> list){
+        return new CounselResponse(list.size(), list);
+    }
+}

--- a/src/main/java/com/aiary/be/global/config/WebClientConfig.java
+++ b/src/main/java/com/aiary/be/global/config/WebClientConfig.java
@@ -2,6 +2,7 @@ package com.aiary.be.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
@@ -9,5 +10,23 @@ public class WebClientConfig {
     @Bean
     public WebClient.Builder webClientBuilder() {
         return WebClient.builder();
+    }
+
+    @Bean
+    public WebClient counselWebClient(WebClient.Builder webClientBuilder){
+        String url = "https://api.odcloud.kr/api";
+
+        // 한 번에 조회 가능한 버퍼 크기를 변경합니다.
+        // 한 번에 3000개 행을 모두 조회하고 filtering 할 거에요.
+        final int size = 10 * 1024 * 1024; // 10MB
+        final ExchangeStrategies strategies = ExchangeStrategies.builder()
+            .codecs(codecs -> codecs.defaultCodecs().maxInMemorySize(size))
+            .build();
+
+        return webClientBuilder
+            .baseUrl(url)
+            .defaultHeader("Accept", "application/json")
+            .exchangeStrategies(strategies)
+            .build();
     }
 }

--- a/src/main/java/com/aiary/be/global/config/WebClientConfig.java
+++ b/src/main/java/com/aiary/be/global/config/WebClientConfig.java
@@ -1,5 +1,6 @@
 package com.aiary.be.global.config;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
@@ -13,6 +14,7 @@ public class WebClientConfig {
     }
 
     @Bean
+    @Qualifier("counselWebClient")
     public WebClient counselWebClient(WebClient.Builder webClientBuilder){
         String url = "https://api.odcloud.kr/api";
 
@@ -21,6 +23,23 @@ public class WebClientConfig {
         final int size = 10 * 1024 * 1024; // 10MB
         final ExchangeStrategies strategies = ExchangeStrategies.builder()
             .codecs(codecs -> codecs.defaultCodecs().maxInMemorySize(size))
+            .build();
+
+        return webClientBuilder
+            .baseUrl(url)
+            .defaultHeader("Accept", "application/json")
+            .exchangeStrategies(strategies)
+            .build();
+    }
+
+    @Bean
+    @Qualifier("kakaoWebClient")
+    public WebClient counselKakaoWebClient(WebClient.Builder webClientBuilder){
+        String url = "https://dapi.kakao.com";
+
+        final int size = 10*1024*1024;
+        final ExchangeStrategies strategies = ExchangeStrategies.builder()
+            .codecs(codecs-> codecs.defaultCodecs().maxInMemorySize(size))
             .build();
 
         return webClientBuilder


### PR DESCRIPTION
### ✔ 작업 내용

---

- 특정 지역의 정신재활센터 리스트를 조회하는 API를 구현했어요.
  - `보건복지부 국립정신건강센터 정신건강 관련기관 정보` 공공데이터를 사용했습니다.
  - 클라이언트에게 query parameter로 시, 구 정보를 받아서 해당 지역의 센터를 조회합니다.  

### ✔ 참고 사항

---

- 제가 활용한 데이터셋이 기관명이랑 기관주소 정도만 나와있어서 위도/경도 정보는 반환하지 않습니다.
- 안드 측과 협의를 좀 해 보고.. 위도/경도가 필요하겠다 싶으면 naver map geocoding API 등을 2차로 활용해서 도로명 주소 -> 위도/경도 가공 및 반환하는 걸로 수정할게요.

### ✔ 버그 리포트

---

x

### ✔ 기타 (레퍼런스, 여담)

---

- 테스트 중 경기데이터포털 사이트가 터지는 억까를 딛고 해냈습니다. 내일 봅시당