### PR TITLE
#16 도로명 주소 정보를 반환하는 메서드의 반환타입을 Mono<ResponseEntity<?>> 타입으로 수정

### DIFF
--- a/src/main/java/com/aiary/be/counsel/application/CounselService.java
+++ b/src/main/java/com/aiary/be/counsel/application/CounselService.java
@@ -2,6 +2,7 @@ package com.aiary.be.counsel.application;
 
 import com.aiary.be.counsel.application.dto.CounselData;
 import com.aiary.be.counsel.application.dto.RawResult;
+import com.aiary.be.counsel.presentation.dto.CounselResponse;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,7 +31,7 @@ public class CounselService {
 
 
     // 시(city), 구(district) 정보를 받아서 해당 지역의 정신재활센터 list를 보여주는 메서드
-    public Mono<List<CounselData>> getCounselListByCity(String city, String district){
+    public Mono<CounselResponse> getCounselListByCity(String city, String district){
 
         return counselWebClient.get()
             .uri(uriBuilder ->uriBuilder
@@ -45,7 +46,8 @@ public class CounselService {
             .bodyToMono(RawResult.class)
             .map(rawResult -> rawResult.data().stream()
                     .filter(counselData -> counselData.adr()!=null && counselData.adr().contains(city))
-                    .toList());
+                    .toList())
+            .map(CounselResponse::from);
     }
 
     // 도로명주소 -> 위도/경도 추출하는 메서드(kakao map API 이용)

--- a/src/main/java/com/aiary/be/counsel/presentation/CounselApiController.java
+++ b/src/main/java/com/aiary/be/counsel/presentation/CounselApiController.java
@@ -2,9 +2,9 @@ package com.aiary.be.counsel.presentation;
 
 import com.aiary.be.counsel.application.CounselService;
 import com.aiary.be.counsel.application.dto.CounselData;
-import com.aiary.be.counsel.presentation.dto.CounselResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -19,14 +19,15 @@ public class CounselApiController {
     private final CounselService counselService;
 
     // 시설의 도로명 주소 리스트를 반환
-    @GetMapping("/roadName")
-    public Mono<?> getCounselRoadNameListByCity(
+    @GetMapping("/roadname")
+    public Mono<ResponseEntity<?>> getCounselRoadNameListByCity(
         @RequestParam(name="city") String city,
         // 시/구까지 받고 있긴 한데, 시만 받아도 괜찮을 것 같긴 해요.
         @RequestParam(name="district") String district
     ){
         return counselService.getCounselListByCity(city, district)
-            .map(CounselResponse::from);
+            .map(ResponseEntity::ok);
+
     }
 
     // 시설의 위도/경도 리스트를 반환: 아직 구현 전


### PR DESCRIPTION
### ✔ 작업 내용

---

- 지역 이름에 따라 도로명 주소 정보를 반환하는 메서드의 반환타입을 수정했어요. 이제 Mono<ResponseEntity<?>> 타입으로 반환됩니다.
-
-

### ✔ 참고 사항

---

- 위도/경도까지 반환하는 건 과감하게 포기
-
-

### ✔ 버그 리포트

---

-
-
-

### ✔ 기타 (레퍼런스, 여담)

---

-
-
-